### PR TITLE
Print token on startup message

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 		protocol += "s"
 	}
 
-	log.Printf("- Running heartbeat on " + protocol + "://" + *addr)
+	log.Printf("- Running heartbeat on " + protocol + "://" + *addr + " with token \"" + ReadFileUnsafe("token") + "\"")
 
 	h := RequestHandler
 	if *compress {


### PR DESCRIPTION
### Description
Useful for debugging 403 errors. Probably the worst way I could of done this.